### PR TITLE
check for "Error!" for login failed

### DIFF
--- a/src/FHue/Hue.hs
+++ b/src/FHue/Hue.hs
@@ -84,7 +84,7 @@ login username password = do
   -- TODO reuse cookie to save time
   hGet "accounts/login/"  -- To get a first CSRF token
   r <- hPost "accounts/login/" [ "username" := username, "password" := password]
-  when ("Error" `isInfixOf` (r ^. responseBody . to L.unpack))  -- TODO ugly
+  when ("Error!" `isInfixOf` (r ^. responseBody . to L.unpack))  -- TODO ugly
     (throw LoginFailed)
 
 


### PR DESCRIPTION
It happens that on a different version of Hue, the "Error" string is in the welcome page when login is successful
